### PR TITLE
Update bibtex.bib

### DIFF
--- a/bibtex.bib
+++ b/bibtex.bib
@@ -1,3 +1,15 @@
+@inproceedings{rahman2022limitations,
+	title={On the Limitations of Continual Learning for Malware Classification},
+	author={Rahman, Mohammad Saidur and Coull, Scott E and Wright, Matthew},
+	booktitle={Conference on Lifelong Learning Agents (CoLLAs)},
+	year={2022}
+	url={https://arxiv.org/abs/2208.06568},
+	keywords={Applications, Empirical Study, Rehearsal, Regularization, Distillation, Generative Replay}
+	}
+@string(rahman2022limitations="This paper investigates overcoming catastrophic forgetting for malware classification")
+
+
+
 @article{boschini2022continual,
 title = {Continual semi-supervised learning through contrastive interpolation consistency},
 journal = {Pattern Recognition Letters},

--- a/bibtex.bib
+++ b/bibtex.bib
@@ -4,7 +4,7 @@
 	booktitle={Conference on Lifelong Learning Agents (CoLLAs)},
 	year={2022}
 	url={https://arxiv.org/abs/2208.06568},
-	keywords={Applications, Empirical Study, Rehearsal, Regularization, Distillation, Generative Replay}
+	keywords={Applications,}
 	}
 @string(rahman2022limitations="This paper investigates overcoming catastrophic forgetting for malware classification")
 


### PR DESCRIPTION
one of the CoLLAs 2022 paper is added.

@inproceedings{rahman2022limitations,
title={On the Limitations of Continual Learning for Malware Classification},
author={Rahman, Mohammad Saidur and Coull, Scott E and Wright, Matthew},
booktitle={Conference on Lifelong Learning Agents (CoLLAs)},
year={2022}
url={[https://arxiv.org/abs/2208.06568}](https://arxiv.org/abs/2208.06568%7D),
keywords={Applications, Empirical Study, Rehearsal, Regularization, Distillation, Generative Replay}
}
https://github.com/string(rahman2022limitations="This paper investigates overcoming catastrophic forgetting for malware classification")